### PR TITLE
chore(ci): add explicit permissions to all workflow files

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,10 @@ on:
       - beta
       - hotfix\/v[0-9]+.[0-9]+.[0-9]+
 
+permissions:
+  contents: read
+  actions: read
+
 jobs:
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -11,6 +11,11 @@ on:
     # random HH:MM to avoid a load spike on GitHub Actions at 00:00
     - cron: 47 11 * * *
 name: Semgrep
+
+permissions:
+  contents: read
+  actions: read
+
 jobs:
   semgrep:
     name: semgrep/ci


### PR DESCRIPTION
Restrict GITHUB_TOKEN to least-privilege permissions (contents: read, actions: read) by default, with per-job overrides where elevated access is needed.