### PR TITLE
fix: grant release workflow GitHub permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      issues: write
       id-token: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:


### PR DESCRIPTION
## Summary

- Keep semantic-release using `secrets.CI_GITHUB_TOKEN` as the release token.
- Grant `issues: write` and `pull-requests: write` to the release job so the built-in GitHub Actions token has the permissions `@semantic-release/github` expects if it is used by release tooling.

## Important

The failed release after merging the Starknet 10 PR reported `EINVALIDGHTOKEN Invalid GitHub token` while using `secrets.CI_GITHUB_TOKEN`. The existing workflow shape matches other working release workflows, and npm OIDC verification succeeded.

That means the repo/org `CI_GITHUB_TOKEN` secret likely needs to be rotated, restored, or given access to `argentlabs/x-sessions`. This PR keeps that token wiring intact; it does not replace the release token with `${{ github.token }}`.

## Release behavior

After `CI_GITHUB_TOKEN` is fixed, rerunning the failed release workflow or pushing/merging to `develop` should let semantic-release pick up the already-merged `feat!: support starknet 10` commit. Because the failed run did not publish/tag successfully, it should still publish the breaking release on the `next` channel.

## Validation

- `git diff --check HEAD~1 HEAD`
- Verified workflow still maps `GITHUB_TOKEN` to `${{ secrets.CI_GITHUB_TOKEN }}`
