### PR TITLE
fix: use automatic GitHub token for release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,5 +50,5 @@ jobs:
         run: npx semantic-release --debug true --dry-run false
         env:
           HUSKY: 0
-          GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_CONFIG_PROVENANCE: "true"


### PR DESCRIPTION
## Summary

- Change semantic-release to use GitHub's automatic Actions token instead of the custom `CI_GITHUB_TOKEN` secret.
- Keep the release job permissions added in #71: `contents: write`, `issues: write`, `pull-requests: write`, and `id-token: write`.

## Why

The release workflow still fails in `@semantic-release/github` with `EINVALIDGHTOKEN` when authenticating with `secrets.CI_GITHUB_TOKEN`. The log shows npm OIDC succeeds and the Git auth check is allowed, so the remaining failure is GitHub API auth for the custom token.

Using `${{ secrets.GITHUB_TOKEN }}` switches semantic-release to GitHub's automatically generated workflow token.

## Note

Releases/tags created with the automatic GitHub token generally do not trigger follow-up workflows. If release-created events need to trigger other workflows, we should restore a valid PAT/App token in `CI_GITHUB_TOKEN` instead.

## Validation

- `git diff --check`
